### PR TITLE
Upgrade dependencies to modern versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.ruby-version
 .bundle
 Gemfile.lock
 pkg

--- a/musicbrainz-ruby.gemspec
+++ b/musicbrainz-ruby.gemspec
@@ -17,9 +17,10 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency('httparty', '~> 0.10.0')
-  s.add_runtime_dependency('hashie',   '~> 1.1.0')
+  s.add_runtime_dependency('httparty', '~> 0.13.3')
+  s.add_runtime_dependency('hashie',   '~> 3.4.0')
 
-  s.add_development_dependency('rspec',   '~> 2.12.0')
+  s.add_development_dependency('rspec',   '~> 3.2.0')
   s.add_development_dependency('fakeweb', '~> 1.3.0')
+  s.add_development_dependency('pry')
 end

--- a/spec/musicbrainz/client_spec.rb
+++ b/spec/musicbrainz/client_spec.rb
@@ -19,7 +19,7 @@ describe MusicBrainz::Client do
 
   it 'specifies a default User-Agent in the headers' do
     expected = /musicbrainz-ruby gem/
-    subject.class.default_options[:headers]['User-Agent'].should =~ expected
+    expect(subject.class.default_options[:headers]['User-Agent']).to match(expected)
   end
 
   context 'when a User-Agent is provided' do
@@ -27,7 +27,7 @@ describe MusicBrainz::Client do
     let(:user_agent) { 'Herp Derp v1.2.3' }
 
     it 'specifies the provided User-Agent in the headers' do
-      subject.class.default_options[:headers]['User-Agent'].should == user_agent
+      expect(subject.class.default_options[:headers]['User-Agent']).to match(user_agent)
     end
   end
 
@@ -42,8 +42,7 @@ describe MusicBrainz::Client do
     end
 
     it 'raises an error' do
-      lambda { subject.artist }.
-        should raise_error(ArgumentError, /Must specify a least one parameter/)
+      expect { subject.artist }.to raise_error(ArgumentError, /Must specify a least one parameter/)
     end
   end
 
@@ -65,9 +64,7 @@ describe MusicBrainz::Client do
       end
 
       it 'returns the resource' do
-        subject.rating(:id => mbid, :entity => entity).
-                user_rating.
-                should == expected_rating
+        expect(subject.rating(:id => mbid, :entity => entity).user_rating).to eq expected_rating
       end
     end
 
@@ -80,8 +77,7 @@ describe MusicBrainz::Client do
       end
 
       it 'raises an error' do
-        lambda { subject.rating(:id => mbid, :entity => entity) }.
-          should raise_error(RuntimeError, /Authorization Required/)
+        expect { subject.rating(:id => mbid, :entity => entity) }.to raise_error(RuntimeError, /Authorization Required/)
       end
     end
 
@@ -104,8 +100,8 @@ describe MusicBrainz::Client do
 
     it 'returns a list of resources' do
       results = subject.artist(:query => query).artist_list.artist
-      results.should be_kind_of(Array)
-      results.size.should == 11
+      expect(results).to be_kind_of(Array)
+      expect(results.size).to eq 11
     end
   end
 
@@ -126,8 +122,8 @@ describe MusicBrainz::Client do
 
     it 'returns a single resource' do
       artist = subject.artist(:mbid => mbid).artist
-      artist.should be_kind_of(Hashie::Mash)
-      artist.name.should == 'Diplo'
+      expect(artist).to be_kind_of(Hashie::Mash)
+      expect(artist.name).to eq 'Diplo'
     end
   end
 


### PR DESCRIPTION
The versions of dependencies was quite outdated, and specifically
httparty did not work with recent Ruby versions. Update to modern
versions of all dependencies, and also use RSpec's `expect` syntax
instead of its `should` syntax.
